### PR TITLE
Refactor getfilecontent functions

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -59,7 +59,7 @@ char *clearblank(size_t *vlen, char *string) {
   while (buffer[*vlen - 1] == ' ' || buffer[*vlen - 1] == '\t')
     (*vlen)--;
 
-  buffer[(*vlen)++] = 0;
+  buffer[*vlen] = 0;
   return buffer;
 }
 

--- a/src/libeconf.c
+++ b/src/libeconf.c
@@ -119,7 +119,7 @@ void econf_write_key_file(Key_File *key_file, const char *save_to_dir,
                      key_file->file_entry[i].group)) {
       if (i)
         fprintf(kf, "\n");
-      if (strcmp(key_file->file_entry[i].group, "[]"))
+      if (strcmp(key_file->file_entry[i].group, KEY_FILE_NULL_VALUE))
         fprintf(kf, "%s\n", key_file->file_entry[i].group);
     }
     fprintf(kf, "%s%c%s\n", key_file->file_entry[i].key, key_file->delimiter,


### PR DESCRIPTION
Refactor the functions associated with reading content from files.
Replace `snprintf` with `strdup` and adapt the functions to the
features introduced in PR:#5.

Signed-off-by: Pascal Arlt <parlt@suse.com>